### PR TITLE
fix(cicd): updating integration workflows

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -1,41 +1,31 @@
-name: delivery
+name: release
 
 on:
+  workflow_dispatch:
   push:
     branches: [master]
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
+
       - name: Checkout files
         uses: actions/checkout@v2
 
-      - name: Lint sources
-        uses: arma-actions/sqflint@v1.0
-        with:
-          args: --exit e --directory FORM_Entrainement.Altis
-
       - name: Make mission pbo
-        uses: team-gsri/actions-make-pbo@master
+        uses: team-gsri/actions-build-mission@0.0.1
         with:
-          mission: FORM_Entrainement.Altis
-          briefingName: "[GSRI] Entrainement"
+          source: ./FORM_Entrainement.Altis
+          target: ./
 
-      - name: Upload pbo to github
+      - name: Upload PBO to github
         uses: actions/upload-artifact@v2
         with:
-          name: mission-pbo
-          path: FORM_Entrainement.Altis.pbo
+          name: mission
+          path: ./*.pbo
 
-      - name: Publish mission to Krypton
-        uses: team-gsri/actions-deploy-mission@master
-        env:
-          SSH_KNOWN_HOSTS: ${{ secrets.SSH_HOSTS_KEYS }}
-          SSH_HOSTNAME: ${{ secrets.SSH_ARMA3_HOSTNAME }}
-          SSH_USERNAME: ${{ secrets.SSH_ARMA3_USERNAME }}
-          SSH_KEY: ${{ secrets.SSH_KEY }}
+      - name: Create Github Release
+        uses: arwynfr/actions-conventional-versioning@0.1.0
         with:
-          localPath: FORM_Entrainement.Altis.pbo
-          remotePath: ${{ secrets.ARMA3_PATH }}/mpmissions/FORM_Entrainement.Altis.pbo
-          instanceName: ${{ secrets.ARMA3_INSTANCE }}
+            pattern: ./*.pbo

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,8 +3,6 @@ name: lint
 on:
   pull_request:
     branches: [master]
-  push:
-    branches: [master]
 
 jobs:
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,8 @@ name: lint
 on:
   pull_request:
     branches: [master]
+  push:
+    branches: [master]
 
 jobs:
   lint:
@@ -12,11 +14,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Lint sources
-        uses: arma-actions/sqflint@v1.0
+        uses: jokoho48/sqflint@master
         with:
           args: --exit e --directory FORM_Entrainement.Altis
-
-      - name: Make mission pbo
-        uses: team-gsri/actions-make-pbo@master
-        with:
-          mission: FORM_Entrainement.Altis

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
     branches: [master]
 
 jobs:
-  publish:
+  release:
     runs-on: self-hosted
     steps:
 
@@ -28,4 +28,4 @@ jobs:
       - name: Create Github Release
         uses: arwynfr/actions-conventional-versioning@0.1.0
         with:
-            pattern: ./*.pbo
+            pattern: $(Convert-Path *.pbo)


### PR DESCRIPTION
This pull request will upgrade the current SQF linter to a more recent version
It adds a conventional commit release system and remove obsolete SSH push deploy system.
It also builds the mission using BI Arma 3 Tools instead of deprecated armake2.

**Note: this PR should be merged before other PRs for them to benefit from this CICD improvements**